### PR TITLE
Fix high uid

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ RUN apt-get update \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/*
 
+# Install official PhantomJS release
+# Install dumb-init (to handle PID 1 correctly).
+# https://github.com/Yelp/dumb-init
+# Runs as non-root user.
+# Cleans up.
 RUN set -x  \
-    # Install official PhantomJS release
  && apt-get update \
  && apt-get install -y --no-install-recommends \
         curl \
@@ -18,17 +22,12 @@ RUN set -x  \
  && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
         | tar -xj --strip-components=1 -C /tmp/phantomjs \
  && mv /tmp/phantomjs/bin/phantomjs /usr/local/bin \
-    # Install dumb-init (to handle PID 1 correctly).
-    # https://github.com/Yelp/dumb-init
  && curl -Lo /tmp/dumb-init.deb https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64.deb \
  && dpkg -i /tmp/dumb-init.deb \
-    # Clean up
  && apt-get purge --auto-remove -y \
         curl \
  && apt-get clean \
  && rm -rf /tmp/* /var/lib/apt/lists/* \
-    \
-    # Run as non-root user.
  && useradd --system --uid 52379 -m --shell /usr/sbin/nologin phantomjs \
  && su phantomjs -s /bin/sh -c "phantomjs --version"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ RUN set -x  \
  && rm -rf /tmp/* /var/lib/apt/lists/* \
     \
     # Run as non-root user.
- && useradd --system --uid 72379 -m --shell /usr/sbin/nologin phantomjs \
+ && useradd --system --uid 52379 -m --shell /usr/sbin/nologin phantomjs \
  && su phantomjs -s /bin/sh -c "phantomjs --version"
 
 USER phantomjs

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This [Dockerized][docker] version of PhantomJS is:
 
  * **Small**: Using [Debian image][debian] (below 100 MB, while Ubuntu is about 230 MB), and removing packages used during build.
  * **Simple**: Exposes default port, easy to extend.
- * **Secure**: Runs as non-root UID/GID `72379` (selected randomly to avoid mapping to an existing user) and uses [dumb-init](https://github.com/Yelp/dumb-init) to reap zombie processes.
+ * **Secure**: Runs as non-root UID/GID `52379` (selected randomly to avoid mapping to an existing user) and uses [dumb-init](https://github.com/Yelp/dumb-init) to reap zombie processes.
 
 
 ## Usage


### PR DESCRIPTION
CircleCI [uses namespaces](https://circleci.com/docs/2.0/high-uid-error/#nav-button) to secure containers running in their environment. The high random UID chosen for the phantomjs user makes this container impossible to use there (or anywhere else using userns AFAICT).

I also fixed a warning thrown by docker build. It does make the comments harder to follow, but if we want to keep everything in one line I think it's the only way. Or, we'd want to refactor into multiple RUN lines with their own cleanup tasks.