### PR TITLE
make 'phantomjs' a part of ENTRYPOINT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,4 @@ USER phantomjs
 
 EXPOSE 8910
 
-ENTRYPOINT ["dumb-init"]
-CMD ["phantomjs"]
+ENTRYPOINT ["dumb-init", "phantomjs"]

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Start PhantomJS in [REPL](http://phantomjs.org/repl.html):
 
 Start as 'Remote WebDriver mode' (embedded [GhostDriver](https://github.com/detro/ghostdriver)):
 
-    $ docker run -d -p 8910:8910 wernight/phantomjs phantomjs --webdriver=8910
+    $ docker run -d -p 8910:8910 wernight/phantomjs --webdriver=8910
 
 To connect to it (some examples per language):
 


### PR DESCRIPTION
It would be more convenient to run the image without specifying `phantomjs` as argument

`docker run -d -p 8910:8910 wernight/phantomjs phantomjs --webdriver=8910`
vs 
`docker run -d -p 8910:8910 wernight/phantomjs --webdriver=8910`

`docker run --rm -v /test.js:/test.js wernight/phantomjs phantomjs /test.js`
vs
`docker run --rm -v /test.js:/test.js wernight/phantomjs /test.js`