### PR TITLE
Arg to choose PhantomJS version at build time

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM debian:jessie
 
+ARG PHANTOM_JS_VERSION
+ENV PHANTOM_JS_VERSION ${PHANTOM_JS_VERSION:-2.1.1-linux-x86_64}
+
 # Install runtime dependencies
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
@@ -19,7 +22,7 @@ RUN set -x  \
  && apt-get install -y --no-install-recommends \
         curl \
  && mkdir /tmp/phantomjs \
- && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2 \
+ && curl -L https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-${PHANTOM_JS_VERSION}.tar.bz2 \
         | tar -xj --strip-components=1 -C /tmp/phantomjs \
  && mv /tmp/phantomjs/bin/phantomjs /usr/local/bin \
  && curl -Lo /tmp/dumb-init.deb https://github.com/Yelp/dumb-init/releases/download/v1.1.3/dumb-init_1.1.3_amd64.deb \


### PR DESCRIPTION
This change makes it possible to specify the PhantomJS version at image build time.

eg. `docker build --build-arg PHANTOM_JS_VERSION=1.9.8-linux-x86_64 -t phantomjs198_image .`

Omitting the build-arg defaults to version 2.1.1