### PR TITLE
Update debian base to stretch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie
+FROM debian:stretch
 
 ARG PHANTOM_JS_VERSION
 ENV PHANTOM_JS_VERSION ${PHANTOM_JS_VERSION:-2.1.1-linux-x86_64}


### PR DESCRIPTION
Previous jessie base had been abandoned, and apt-get install doesn't work for the extended image anymore.
I have tested the build based on the new base, and it works flawlessly.